### PR TITLE
fix: several fixes to import models generated from Revit

### DIFF
--- a/dragonfly_doe2/doe/hvac.py
+++ b/dragonfly_doe2/doe/hvac.py
@@ -52,7 +52,7 @@ class Zone:
             f'DESIGN-HEAT-T    = {self.heating_setpoint}\n  ' \
             f'DESIGN-COOL-T    = {self.cooling_setpoint}\n  ' \
             'SIZING-OPTION    = ADJUST-LOADS\n  ' \
-            f'SPACE            = {self.name}\n  ..\n'
+            f'SPACE            = "{self.name}"\n  ..\n'
         return inp_str
 
     def __repr__(self) -> str:

--- a/dragonfly_doe2/doe/polygon.py
+++ b/dragonfly_doe2/doe/polygon.py
@@ -17,10 +17,10 @@ class Polygon(object):
     def from_room(cls, room: Room2D, tolerace=0.01):
         """
         Note: Shouldn't we ensure the points are in 2D. I'm not sure how it works.
-        #TF: ooohhhhhhhhhh good catch!! Though is there not already built into DF somthhing
+        #TF: ooohhhhhhhhhh good catch!! Though is there not already built into DF something
             of the sort for room.floor_geom? was operating off the *assumption* that obj.prop
             would be good to go as is? or am I misunderstanding the specifics in which should
-            do check: raise exeption if issue?
+            do check: raise exception if issue?
         """
         room.remove_duplicate_vertices()
         # TODO: on refactor, need to minimize the disconnect between the poly and 'space' room
@@ -28,16 +28,21 @@ class Polygon(object):
         return cls(room.display_name, vertices)
 
     @classmethod
-    def from_story(cls, story: Story, tolerace=0.01):
+    def from_story(cls, story: Story, tolerance=0.01):
         """
         Note: I'm not sure if this is correct - shouldn't we create a polygon per face?
         This is based on the initial code by Trevor so I didn't change it.
         """
-        geo = story.footprint(tolerance=tolerace)
-        vertices = []
-        for face in geo:
-            vertices.extend(face.lower_left_counter_clockwise_vertices)
-        return cls(story.display_name, vertices)
+        geo = story.footprint(tolerance=tolerance)[0]
+        # 
+        b_pts = geo.boundary
+        # remove duplicate vertices if any
+        new_bound = []
+        b_pts = b_pts[1:] + (b_pts[0],)
+        for i, vert in enumerate(b_pts):
+            if not vert.is_equivalent(b_pts[i - 1], tolerance):
+                new_bound.append(b_pts[i - 1])
+        return cls(story.display_name, new_bound)
 
     def to_inp(self) -> str:
         """Return Room Polygons block input"""

--- a/dragonfly_doe2/doe/utils.py
+++ b/dragonfly_doe2/doe/utils.py
@@ -2,7 +2,7 @@ import re
 from ladybug.datatype import UNITS as lbt_units, TYPESDICT as lbt_td
 
 
-def short_name(name, max_length):
+def short_name(name, max_length=32):
     if len(name) <= max_length:
         return name
 

--- a/dragonfly_doe2/writer.py
+++ b/dragonfly_doe2/writer.py
@@ -19,7 +19,6 @@ def model_to_inp(
     """
 
     # TODO: add all the other arguments that one might to pass to the model
-    model.to_rectangular_windows()
     inp_model = Model.from_df_model(model)
 
     # write to inp


### PR DESCRIPTION
Here is the shortlist:

1. Catch the case when both `floor_height` and `floor_to_floor_height` are set to 0. I'm using the Room properties to get them instead.
2. Remove the holes from story polygon. We we removing it from the rooms already but not from the story floorplate.
3. Caught a few cases where names where not inside double quotes.
4. Shorten the name for floor space with index
5. Purge duplicate window constructions
